### PR TITLE
6 update board using diff

### DIFF
--- a/canvas_board.py
+++ b/canvas_board.py
@@ -36,6 +36,11 @@ class CanvasBoard:
         start_ind = row * (self.width * 4) + col * 4
         return tuple(self.data[start_ind:start_ind + 4])
 
+    def updateBoard(self, coord: list, val: list):
+        numPixels = len(coord)
+        for i in range(numPixels):
+            self.data[coord[i]] = val[i]
+
 class CanvasBoardEncoder(JSONEncoder):
     def default(self, o):
         return o.__dict__

--- a/canvas_board.py
+++ b/canvas_board.py
@@ -1,3 +1,5 @@
+from json import JSONEncoder
+
 class CanvasBoard:
     """Represents the image data of the canvas board.
 
@@ -33,3 +35,7 @@ class CanvasBoard:
                 .format(row, col, self.height, self.width))
         start_ind = row * (self.width * 4) + col * 4
         return tuple(self.data[start_ind:start_ind + 4])
+
+class CanvasBoardEncoder(JSONEncoder):
+    def default(self, o):
+        return o.__dict__

--- a/server.py
+++ b/server.py
@@ -22,6 +22,7 @@ class Server:
         self.lock.acquire()
         self.board.updateBoard(diff['coord'], diff['val'])
         self.lock.release()
+
 # instantiate server class for board state
 imagedata = {
     'width': WIDTH,

--- a/server.py
+++ b/server.py
@@ -28,7 +28,7 @@ imagedata = {
 }
 server = Server(imagedata)
 
-@app.route('/canvas')
+@socketio.on('connect', namespace='/canvas')
 def connect_canvas():
     # broadcast board upon initial connect at /canvas endpoint
     emit('broadcast-board', server.board)

--- a/server.py
+++ b/server.py
@@ -1,5 +1,4 @@
 import threading
-import json
 from flask import Flask
 from flask_socketio import SocketIO, emit
 from canvas_board import CanvasBoard, CanvasBoardEncoder
@@ -50,6 +49,9 @@ def on_disconnect():
 def handle_send_stroke(diff):
     # diff -> dict
     server.updateBoard(diff)
+    # turn board into JSON
+    board = CanvasBoardEncoder().encode(server.board)
+    emit('broadcast-board', board)
 
 if __name__ == "__main__":
     socketio.run(app, port=PORT, debug=True)

--- a/server.py
+++ b/server.py
@@ -1,7 +1,7 @@
 import threading
 from flask import Flask
 from flask_socketio import SocketIO, emit
-from canvas_board import CanvasBoard
+from canvas_board import CanvasBoard, CanvasBoardEncoder
 
 # constants
 PORT = 8080
@@ -31,7 +31,9 @@ server = Server(imagedata)
 @socketio.on('connect', namespace='/canvas')
 def connect_canvas():
     # broadcast board upon initial connect at /canvas endpoint
-    emit('broadcast-board', server.board)
+    # turn board into JSON
+    board = CanvasBoardEncoder().encode(server.board)
+    emit('broadcast-board', board)
 
 @socketio.on('connect')
 def on_connect():

--- a/server.py
+++ b/server.py
@@ -28,6 +28,11 @@ imagedata = {
 }
 server = Server(imagedata)
 
+@app.route('/canvas')
+def connect_canvas():
+    # broadcast board upon initial connect at /canvas endpoint
+    emit('broadcast-board', server.board)
+
 @socketio.on('connect')
 def on_connect():
     print("connected to websocket")

--- a/server.py
+++ b/server.py
@@ -37,10 +37,6 @@ def connect_canvas():
     board = CanvasBoardEncoder().encode(server.board)
     emit('broadcast-board', board)
 
-@socketio.on('connect')
-def on_connect():
-    print("connected to websocket")
-
 @socketio.on('disconnect')
 def on_disconnect():
     print("disconnected from websocket")

--- a/server.py
+++ b/server.py
@@ -18,10 +18,10 @@ class Server:
     def __init__(self, imagedata):
         self.board = CanvasBoard(imagedata)
         self.lock = threading.Lock()
-    def updateBoard(self, diff_as_dict):
-        numPixels = len(diff_as_dict['coord'])
-        for i in range(numPixels):
-            self.board.data[diff_as_dict['coord'][i]] = diff_as_dict['val'][i]
+    def updateBoard(self, diff: dict):
+        self.lock.acquire()
+        self.board.updateBoard(diff['coord'], diff['val'])
+        self.lock.release()
 # instantiate server class for board state
 imagedata = {
     'width': WIDTH,

--- a/static/main.js
+++ b/static/main.js
@@ -35,9 +35,9 @@ function endPos() {
 	ctx.beginPath();
 
 	// send info using websocket
-	const snapshot = ctx.getImageData(0, 0, canvas.width, canvas.height);
-	console.log(snapshot);
-	socket.emit('send-stroke', snapshot);
+	const board_after = ctx.getImageData(0, 0, canvas.width, canvas.height);
+	console.log(board_after);
+	socket.emit('send-stroke', board_after);
 }
 function draw(e) {
 	if (!painting) {

--- a/static/main.js
+++ b/static/main.js
@@ -10,14 +10,15 @@ canvas.width = 500;
 var board_initial;
 
 // Socket.io
-var socket = io('http://localhost:8080')
+var socket = io('http://localhost:8080/canvas')
 socket.on('connect', function () {
 	console.log(socket.id);
 });
 
 socket.on('broadcast-board', function (imagedata) {
 	console.log(imagedata);
-	ctx.putImageData(imageData, 0, 0);
+	ctx.putImageData(imagedata, 0, 0);
+	ctx.getImageData(0, 0, canvas.width, canvas.height);
 });
 
 // detecting drawing action

--- a/static/main.js
+++ b/static/main.js
@@ -16,7 +16,12 @@ socket.on('connect', function () {
 });
 
 socket.on('broadcast-board', function (imagedata) {
+	// turn JSON into imageData
+	imagedata = JSON.parse(imagedata);
+	array = new Uint8ClampedArray(imagedata.data);
 	console.log(imagedata);
+	// create new ImageData & update board
+	imagedata = new ImageData(array,imagedata.width,imagedata.height);
 	ctx.putImageData(imagedata, 0, 0);
 	board_initial = ctx.getImageData(0, 0, canvas.width, canvas.height);
 });

--- a/static/main.js
+++ b/static/main.js
@@ -38,10 +38,9 @@ function endPos() {
 	// reset path every time when ending
 	// fixes lines being all connected
 	ctx.beginPath();
-
+	// get final board state
 	const board_after = ctx.getImageData(0, 0, canvas.width, canvas.height);
 	console.log(board_after);
-
 	// get difference btw initial & after board
 	let coord = [];
 	let val = [];
@@ -51,13 +50,11 @@ function endPos() {
 	        val.push(board_after.data[i]);
 	    }
 	}
-
 	// create JSON
 	var diff = {
 	    "coord" : coord,
 	    "val" : val
 	};
-
     console.log(diff)
 	socket.emit('send-stroke', diff);
 }

--- a/static/main.js
+++ b/static/main.js
@@ -25,6 +25,25 @@ socket.on('broadcast-board', function (imagedata) {
 	ctx.putImageData(imagedata, 0, 0);
 });
 
+// get difference btw initial & after board
+function getDiff(board_i, board_a) {
+    let coord = [];
+	let val = [];
+	for (let i = 0; i < board_a.data.length; i++) {
+	    if (board_i.data[i] != board_a.data[i]) {
+	        coord.push(i);
+	        val.push(board_a.data[i]);
+	    }
+	}
+	// create JSON
+	var diff = {
+	    "coord" : coord,
+	    "val" : val
+	};
+    console.log(diff)
+    return diff
+}
+
 // detecting drawing action
 let painting = false;
 function startPos(e) {
@@ -41,21 +60,8 @@ function endPos() {
 	// get final board state
 	const board_after = ctx.getImageData(0, 0, canvas.width, canvas.height);
 	console.log(board_after);
-	// get difference btw initial & after board
-	let coord = [];
-	let val = [];
-	for (let i = 0; i < board_after.data.length; i++) {
-	    if (board_initial.data[i] != board_after.data[i]) {
-	        coord.push(i);
-	        val.push(board_after.data[i]);
-	    }
-	}
-	// create JSON
-	var diff = {
-	    "coord" : coord,
-	    "val" : val
-	};
-    console.log(diff)
+	// get difference & emit
+	diff = getDiff(board_initial, board_after);
 	socket.emit('send-stroke', diff);
 }
 function draw(e) {

--- a/static/main.js
+++ b/static/main.js
@@ -19,7 +19,6 @@ socket.on('broadcast-board', function (imagedata) {
 
 // detecting drawing action
 let painting = false;
-let stroke = [];
 function startPos(e) {
 	painting = true;
 	// fix not drawing when clicking

--- a/static/main.js
+++ b/static/main.js
@@ -39,7 +39,6 @@ function endPos() {
 	// fixes lines being all connected
 	ctx.beginPath();
 
-	// send info using websocket
 	const board_after = ctx.getImageData(0, 0, canvas.width, canvas.height);
 	console.log(board_after);
 

--- a/static/main.js
+++ b/static/main.js
@@ -37,7 +37,25 @@ function endPos() {
 	// send info using websocket
 	const board_after = ctx.getImageData(0, 0, canvas.width, canvas.height);
 	console.log(board_after);
-	socket.emit('send-stroke', board_after);
+
+	// get difference btw initial & after board
+	let coord = [];
+	let val = [];
+	for (let i = 0; i < board_after.data.length; i++) {
+	    if (board_initial.data[i] != board_after.data[i]) {
+	        coord.push(i);
+	        val.push(board_after.data[i]);
+	    }
+	}
+
+	// create JSON
+	var diff = {
+	    "coord" : coord,
+	    "val" : val
+	};
+
+    console.log(diff)
+	socket.emit('send-stroke', diff);
 }
 function draw(e) {
 	if (!painting) {

--- a/static/main.js
+++ b/static/main.js
@@ -6,6 +6,9 @@ const ctx = canvas.getContext("2d");
 canvas.height = 500;
 canvas.width = 500;
 
+// variable for initial board state
+var board_initial;
+
 // Socket.io
 var socket = io('http://localhost:8080')
 socket.on('connect', function () {

--- a/static/main.js
+++ b/static/main.js
@@ -28,7 +28,7 @@ socket.on('broadcast-board', function (imagedata) {
 // get difference btw initial & after board
 function getDiff(board_i, board_a) {
     let coord = [];
-	let val = [];
+    let val = [];
 	for (let i = 0; i < board_a.data.length; i++) {
 	    if (board_i.data[i] != board_a.data[i]) {
 	        coord.push(i);

--- a/static/main.js
+++ b/static/main.js
@@ -23,12 +23,12 @@ socket.on('broadcast-board', function (imagedata) {
 	// create new ImageData & update board
 	imagedata = new ImageData(array,imagedata.width,imagedata.height);
 	ctx.putImageData(imagedata, 0, 0);
-	board_initial = ctx.getImageData(0, 0, canvas.width, canvas.height);
 });
 
 // detecting drawing action
 let painting = false;
 function startPos(e) {
+	board_initial = ctx.getImageData(0, 0, canvas.width, canvas.height);
 	painting = true;
 	// fix not drawing when clicking
 	draw(e);

--- a/static/main.js
+++ b/static/main.js
@@ -18,7 +18,7 @@ socket.on('connect', function () {
 socket.on('broadcast-board', function (imagedata) {
 	console.log(imagedata);
 	ctx.putImageData(imagedata, 0, 0);
-	ctx.getImageData(0, 0, canvas.width, canvas.height);
+	board_initial = ctx.getImageData(0, 0, canvas.width, canvas.height);
 });
 
 // detecting drawing action

--- a/test_server.py
+++ b/test_server.py
@@ -24,13 +24,13 @@ class TestSocketIO(unittest.TestCase):
 
     def test_connect_canvas_emitsBoardAsJSON(self):
         client = server.socketio.test_client(server.app)
-        server_expected = server.server.board
+        board_expected = server.CanvasBoardEncoder().encode(server.server.board)
 
         client.connect('/canvas')
 
         received_data = client.get_received('/canvas')
-        server_output = received_data[0]['args'][0]
-        self.assertEqual(server_expected,server_output)
+        board_output = received_data[0]['args'][0]
+        self.assertEqual(board_expected,board_output)
 
 if __name__ == '__main__':
     unittest.main()

--- a/test_server.py
+++ b/test_server.py
@@ -5,14 +5,6 @@ import server
 
 class TestSocketIO(unittest.TestCase):
 
-    def test_connect_printsConnectionMessage(self):
-        expectedOutput = "connected to websocket\n"
-
-        with patch('sys.stdout', new=io.StringIO()) as myOutput:
-            client = server.socketio.test_client(server.app)
-
-            self.assertEqual(myOutput.getvalue(), expectedOutput)
-
     def test_disconnect_printsDisconnectionMessage(self):
         client = server.socketio.test_client(server.app)
         expectedOutput = "disconnected from websocket\n"

--- a/test_server.py
+++ b/test_server.py
@@ -32,8 +32,5 @@ class TestSocketIO(unittest.TestCase):
         server_output = received_data[0]['args'][0]
         self.assertEqual(server_expected,server_output)
 
-
-
-
 if __name__ == '__main__':
     unittest.main()

--- a/test_server.py
+++ b/test_server.py
@@ -22,5 +22,18 @@ class TestSocketIO(unittest.TestCase):
 
             self.assertEqual(myOutput.getvalue(), expectedOutput)
 
+    def test_connect_canvas_emitsBoardAsJSON(self):
+        client = server.socketio.test_client(server.app)
+        server_expected = server.server.board
+
+        client.connect('/canvas')
+
+        received_data = client.get_received('/canvas')
+        server_output = received_data[0]['args'][0]
+        self.assertEqual(server_expected,server_output)
+
+
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
**main.js**
- now connects to '/canvas' endpoint instead of '/'
- takes a snapshot of the board before (when board was broadcast through 'broadcast-board' event) & after stroke to compare and find the difference
- sends the difference as JSON (with 2 attributes => 'coord' which is a list of coordinates and 'val' which is a list of values for the coordinate with the same index) to server

**canvas_board.py**
- now includes JSON encoder to convert CanvasBoard Python object into JSON

**server.py**
- 'broadcast-board' event sends CanvasBoard as JSON to the client
- now includes 'handle_send_stroke' function that updates the board given the difference (automatically parsed as dict) from the 'send-stroke' event from the client